### PR TITLE
Switch base image to node:alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:latest
+FROM node:alpine
+
+RUN apk update && apk add git
 
 ENV NODE_ENV=production
 ENV PORT=8080


### PR DESCRIPTION
This reduces the Docker image size from 883MB to 284MB.

Note: I've disabled Travis branch builds for this repo, so merging this PR won't deploy Hollowbot.